### PR TITLE
fix: home appliance model

### DIFF
--- a/src/aiohomeconnect/model/appliance.py
+++ b/src/aiohomeconnect/model/appliance.py
@@ -12,13 +12,13 @@ from mashumaro.mixins.json import DataClassJSONMixin
 class HomeAppliance(DataClassJSONMixin):
     """Represent HomeAppliance."""
 
-    ha_id: str | None = field(metadata=field_options(alias="haId"))
-    name: str | None
-    type: str | None
-    brand: str | None
-    vib: str | None
-    e_number: str | None = field(metadata=field_options(alias="enumber"))
-    connected: bool | None
+    ha_id: str = field(metadata=field_options(alias="haId"))
+    name: str
+    type: str
+    brand: str
+    vib: str
+    e_number: str = field(metadata=field_options(alias="enumber"))
+    connected: bool
 
 
 @dataclass


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Although at https://apiclient.home-connect.com/hcsdk.yaml says at `HomeAppliance` definition that there are no required properties,  `ArrayOfHomeAppliances` does have all its properties required.

Also, at testing, when requesting a single appliance, it does have all the properties.

These things lead to me to think that it is an error in the definition

(I mean, if you request an specific appliance so you use its `haId`, why would the API answer without the same `haId` used?)

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
