### PR TITLE
fix: set default values for optional model attributes

### DIFF
--- a/scripts/swagger_model.py
+++ b/scripts/swagger_model.py
@@ -204,7 +204,7 @@ class DefinitionModelUnknown(DefinitionModelBase):
         self, definition: str, *, generate_class: bool = False, required: bool = False
     ) -> str:
         """Return the Python code as a string for this model."""
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         return f"Any{suffix}"
 
 
@@ -216,7 +216,7 @@ class DefinitionModelString(DefinitionModelBase):
         self, definition: str, *, generate_class: bool = False, required: bool = False
     ) -> str:
         """Return the Python code as a string for this model."""
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         return f"str{suffix}"
 
 
@@ -232,7 +232,7 @@ class DefinitionModelStringEnum(DefinitionModelBase):
         """Return the Python code as a string for this model."""
         if (description := self.description) is None:
             raise ValueError("Missing description")
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         if generate_class:
             code_enum = "\n    ".join(
                 f'{enum.upper()} = "{enum}"' for enum in self.enum
@@ -257,7 +257,7 @@ class DefinitionModelInteger(DefinitionModelBase):
         self, definition: str, *, generate_class: bool = False, required: bool = False
     ) -> str:
         """Return the Python code as a string for this model."""
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         return f"int{suffix}"
 
 
@@ -269,7 +269,7 @@ class DefinitionModelBoolean(DefinitionModelBase):
         self, definition: str, *, generate_class: bool = False, required: bool = False
     ) -> str:
         """Return the Python code as a string for this model."""
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         return f"bool{suffix}"
 
 
@@ -281,7 +281,7 @@ class DefinitionModelStringNumberBoolean(DefinitionModelBase):
         self, definition: str, *, generate_class: bool = False, required: bool = False
     ) -> str:
         """Return the Python code as a string for this model."""
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         return f"str | float | bool{suffix}"
 
 
@@ -304,7 +304,7 @@ class DefinitionModelArray(DefinitionModelBase):
         self, definition: str, *, generate_class: bool = False, required: bool = False
     ) -> str:
         """Return the Python code as a string for this model."""
-        suffix = "" if required else " | None"
+        suffix = "" if required else " | None = None"
         if definition != self.definition and generate_class:
             item = definition
             if definition not in self.all_definitions:
@@ -315,7 +315,7 @@ class DefinitionModelArray(DefinitionModelBase):
                     "\n\n"
                 )
         else:
-            item = self.items.generate_code(definition)
+            item = self.items.generate_code(definition, required=True)
 
         self.generated_classes.update(self.items.generated_classes)
         self.items.generated_classes.clear()
@@ -347,7 +347,7 @@ class DefinitionModelObject(DefinitionModelBase):
     ) -> str:
         """Return the Python code as a string for this model."""
         if definition != self.definition and generate_class:
-            suffix = "" if required else " | None"
+            suffix = "" if required else " | None = None"
             if definition not in self.all_definitions:
                 self.generated_classes.add(
                     "\n\n"

--- a/scripts/swagger_model.py
+++ b/scripts/swagger_model.py
@@ -365,7 +365,7 @@ class DefinitionModelObject(DefinitionModelBase):
 
         generate_class = False
         original_definition = definition
-        for prop, model in self.properties.items():
+        for prop, model in sorted_properties.items():
             required_property = bool(
                 required_properties and prop in required_properties
             )

--- a/src/aiohomeconnect/model/appliance.py
+++ b/src/aiohomeconnect/model/appliance.py
@@ -12,13 +12,13 @@ from mashumaro.mixins.json import DataClassJSONMixin
 class HomeAppliance(DataClassJSONMixin):
     """Represent HomeAppliance."""
 
-    ha_id: str | None = field(metadata=field_options(alias="haId"))
-    name: str | None
-    type: str | None
-    brand: str | None
-    vib: str | None
-    e_number: str | None = field(metadata=field_options(alias="enumber"))
-    connected: bool | None
+    ha_id: str | None = field(default=None, metadata=field_options(alias="haId"))
+    name: str | None = None
+    type: str | None = None
+    brand: str | None = None
+    vib: str | None = None
+    e_number: str | None = field(default=None, metadata=field_options(alias="enumber"))
+    connected: bool | None = None
 
 
 @dataclass

--- a/src/aiohomeconnect/model/command.py
+++ b/src/aiohomeconnect/model/command.py
@@ -21,7 +21,7 @@ class Command(DataClassJSONMixin):
     """Represent Command."""
 
     key: CommandKey
-    name: str | None
+    name: str | None = None
 
 
 @dataclass

--- a/src/aiohomeconnect/model/error.py
+++ b/src/aiohomeconnect/model/error.py
@@ -12,7 +12,7 @@ class UnauthorizedError(DataClassJSONMixin):
     """Represent UnauthorizedError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -20,7 +20,7 @@ class ForbiddenError(DataClassJSONMixin):
     """Represent ForbiddenError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -28,7 +28,7 @@ class NotFoundError(DataClassJSONMixin):
     """Represent NotFoundError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -36,7 +36,7 @@ class NoProgramSelectedError(DataClassJSONMixin):
     """Represent NoProgramSelectedError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -44,7 +44,7 @@ class NoProgramActiveError(DataClassJSONMixin):
     """Represent NoProgramActiveError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -52,7 +52,7 @@ class NotAcceptableError(DataClassJSONMixin):
     """Represent NotAcceptableError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -60,7 +60,7 @@ class RequestTimeoutError(DataClassJSONMixin):
     """Represent RequestTimeoutError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -68,7 +68,7 @@ class ConflictError(DataClassJSONMixin):
     """Represent ConflictError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -76,7 +76,7 @@ class SelectedProgramNotSetError(DataClassJSONMixin):
     """Represent SelectedProgramNotSetError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -84,7 +84,7 @@ class ActiveProgramNotSetError(DataClassJSONMixin):
     """Represent ActiveProgramNotSetError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -92,7 +92,7 @@ class WrongOperationStateError(DataClassJSONMixin):
     """Represent WrongOperationStateError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -100,7 +100,7 @@ class ProgramNotAvailableError(DataClassJSONMixin):
     """Represent ProgramNotAvailableError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -108,7 +108,7 @@ class UnsupportedMediaTypeError(DataClassJSONMixin):
     """Represent UnsupportedMediaTypeError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -116,7 +116,7 @@ class TooManyRequestsError(DataClassJSONMixin):
     """Represent TooManyRequestsError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -124,7 +124,7 @@ class InternalServerError(DataClassJSONMixin):
     """Represent InternalServerError."""
 
     key: str
-    description: str | None
+    description: str | None = None
 
 
 @dataclass
@@ -132,4 +132,4 @@ class Conflict(DataClassJSONMixin):
     """Represent Conflict."""
 
     key: str
-    description: str | None
+    description: str | None = None

--- a/src/aiohomeconnect/model/image.py
+++ b/src/aiohomeconnect/model/image.py
@@ -20,8 +20,8 @@ class Image(DataClassJSONMixin):
     """Represent Image."""
 
     key: str
-    name: str | None
     image_key: str = field(metadata=field_options(alias="imagekey"))
     preview_image_key: str = field(metadata=field_options(alias="previewimagekey"))
     timestamp: int
     quality: str
+    name: str | None = None

--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -15,16 +15,16 @@ class Program(DataClassJSONMixin):
     """Represent Program."""
 
     key: ProgramKey
-    name: str | None
-    options: list[Option] | None
-    constraints: ProgramConstraints | None
+    name: str | None = None
+    options: list[Option] | None = None
+    constraints: ProgramConstraints | None = None
 
 
 @dataclass
 class ProgramConstraints(DataClassJSONMixin):
     """Represent ProgramConstraints."""
 
-    access: str | None
+    access: str | None = None
 
 
 @dataclass
@@ -38,7 +38,7 @@ class ArrayOfAvailablePrograms(DataClassJSONMixin):
 class EnumerateAvailableProgramConstraints(DataClassJSONMixin):
     """Represent EnumerateAvailableProgramConstraints."""
 
-    execution: Execution | None
+    execution: Execution | None = None
 
 
 @dataclass
@@ -46,8 +46,8 @@ class EnumerateAvailableProgram(DataClassJSONMixin):
     """Represent EnumerateAvailableProgram."""
 
     key: ProgramKey
-    name: str | None
-    constraints: EnumerateAvailableProgramConstraints | None
+    name: str | None = None
+    constraints: EnumerateAvailableProgramConstraints | None = None
 
 
 @dataclass
@@ -55,16 +55,16 @@ class ArrayOfPrograms(DataClassJSONMixin):
     """Represent ArrayOfPrograms."""
 
     programs: list[EnumerateProgram]
-    active: Program | None
-    selected: Program | None
+    active: Program | None = None
+    selected: Program | None = None
 
 
 @dataclass
 class EnumerateProgramConstraints(DataClassJSONMixin):
     """Represent EnumerateProgramConstraints."""
 
-    available: bool | None
-    execution: Execution | None
+    available: bool | None = None
+    execution: Execution | None = None
 
 
 @dataclass
@@ -72,8 +72,8 @@ class EnumerateProgram(DataClassJSONMixin):
     """Represent EnumerateProgram."""
 
     key: ProgramKey
-    name: str | None
-    constraints: EnumerateProgramConstraints | None
+    name: str | None = None
+    constraints: EnumerateProgramConstraints | None = None
 
 
 class Execution(StrEnum):
@@ -90,25 +90,29 @@ class ProgramDefinition(DataClassJSONMixin):
     """Represent ProgramDefinition."""
 
     key: ProgramKey
-    name: str | None
-    options: list[ProgramDefinitionOption] | None
+    name: str | None = None
+    options: list[ProgramDefinitionOption] | None = None
 
 
 @dataclass
 class ProgramDefinitionConstraints(DataClassJSONMixin):
     """Represent ProgramDefinitionConstraints."""
 
-    min: int | None
-    max: int | None
-    step_size: int | None = field(metadata=field_options(alias="stepsize"))
+    min: int | None = None
+    max: int | None = None
+    step_size: int | None = field(
+        default=None, metadata=field_options(alias="stepsize")
+    )
     allowed_values: list[str | None] | None = field(
-        metadata=field_options(alias="allowedvalues")
+        default=None, metadata=field_options(alias="allowedvalues")
     )
     display_values: list[str | None] | None = field(
-        metadata=field_options(alias="displayvalues")
+        default=None, metadata=field_options(alias="displayvalues")
     )
-    default: Any | None
-    live_update: bool | None = field(metadata=field_options(alias="liveupdate"))
+    default: Any | None = None
+    live_update: bool | None = field(
+        default=None, metadata=field_options(alias="liveupdate")
+    )
 
 
 @dataclass
@@ -116,10 +120,10 @@ class ProgramDefinitionOption(DataClassJSONMixin):
     """Represent ProgramDefinitionOption."""
 
     key: OptionKey
-    name: str | None
     type: str
-    unit: str | None
-    constraints: ProgramDefinitionConstraints | None
+    name: str | None = None
+    unit: str | None = None
+    constraints: ProgramDefinitionConstraints | None = None
 
 
 @dataclass
@@ -127,10 +131,12 @@ class Option(DataClassJSONMixin):
     """Represent Option."""
 
     key: OptionKey
-    name: str | None
     value: Any
-    display_value: str | None = field(metadata=field_options(alias="displayvalue"))
-    unit: str | None
+    name: str | None = None
+    display_value: str | None = field(
+        default=None, metadata=field_options(alias="displayvalue")
+    )
+    unit: str | None = None
 
 
 @dataclass

--- a/src/aiohomeconnect/model/setting.py
+++ b/src/aiohomeconnect/model/setting.py
@@ -15,29 +15,33 @@ class GetSetting(DataClassJSONMixin):
     """Specific setting of the home appliance."""
 
     key: SettingKey
-    name: str | None
     value: Any
-    display_value: str | None = field(metadata=field_options(alias="displayvalue"))
-    unit: str | None
-    type: str | None
-    constraints: SettingConstraints | None
+    name: str | None = None
+    display_value: str | None = field(
+        default=None, metadata=field_options(alias="displayvalue")
+    )
+    unit: str | None = None
+    type: str | None = None
+    constraints: SettingConstraints | None = None
 
 
 @dataclass
 class SettingConstraints(DataClassJSONMixin):
     """Represent SettingConstraints."""
 
-    min: int | None
-    max: int | None
-    step_size: int | None = field(metadata=field_options(alias="stepsize"))
+    min: int | None = None
+    max: int | None = None
+    step_size: int | None = field(
+        default=None, metadata=field_options(alias="stepsize")
+    )
     allowed_values: list[str | None] | None = field(
-        metadata=field_options(alias="allowedvalues")
+        default=None, metadata=field_options(alias="allowedvalues")
     )
     display_values: list[str | None] | None = field(
-        metadata=field_options(alias="displayvalues")
+        default=None, metadata=field_options(alias="displayvalues")
     )
-    default: Any | None
-    access: str | None
+    default: Any | None = None
+    access: str | None = None
 
 
 @dataclass

--- a/src/aiohomeconnect/model/status.py
+++ b/src/aiohomeconnect/model/status.py
@@ -15,29 +15,33 @@ class Status(DataClassJSONMixin):
     """Represent Status."""
 
     key: StatusKey
-    name: str | None
     value: Any
-    display_value: str | None = field(metadata=field_options(alias="displayvalue"))
-    unit: str | None
-    type: str | None
-    constraints: StatusConstraints | None
+    name: str | None = None
+    display_value: str | None = field(
+        default=None, metadata=field_options(alias="displayvalue")
+    )
+    unit: str | None = None
+    type: str | None = None
+    constraints: StatusConstraints | None = None
 
 
 @dataclass
 class StatusConstraints(DataClassJSONMixin):
     """Represent StatusConstraints."""
 
-    min: int | None
-    max: int | None
-    step_size: int | None = field(metadata=field_options(alias="stepsize"))
+    min: int | None = None
+    max: int | None = None
+    step_size: int | None = field(
+        default=None, metadata=field_options(alias="stepsize")
+    )
     allowed_values: list[str | None] | None = field(
-        metadata=field_options(alias="allowedvalues")
+        default=None, metadata=field_options(alias="allowedvalues")
     )
     display_values: list[str | None] | None = field(
-        metadata=field_options(alias="displayvalues")
+        default=None, metadata=field_options(alias="displayvalues")
     )
-    default: Any | None
-    access: str | None
+    default: Any | None = None
+    access: str | None = None
 
 
 @dataclass


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Following to some changes we already did at `events.py` , I added the default value to optional model attributes.

I also updated `swagger_model.py` so that future usages fit on these changes.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
