### PR TITLE
feat: support unknown enum values

### DIFF
--- a/src/aiohomeconnect/model/event.py
+++ b/src/aiohomeconnect/model/event.py
@@ -67,6 +67,12 @@ class EventMessage:
 class EventKey(StrEnum):
     """Represent an event key."""
 
+    @classmethod
+    def _missing_(cls, _: object) -> EventKey:
+        """Return UNKNOWN for missing keys."""
+        return cls.UNKNOWN
+
+    UNKNOWN = "unknown"
     BSH_COMMON_APPLIANCE_CONNECTED = "BSH.Common.Appliance.Connected"
     BSH_COMMON_APPLIANCE_DEPAIRED = "BSH.Common.Appliance.Depaired"
     BSH_COMMON_APPLIANCE_DISCONNECTED = "BSH.Common.Appliance.Disconnected"

--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -154,6 +154,12 @@ class OptionKey(StrEnum):
     # Missing option categories still to be added 20241129:
     # Dryer, Hood, Oven, Warming Drawer, Washer
 
+    @classmethod
+    def _missing_(cls, _: object) -> OptionKey:
+        """Return UNKNOWN for missing keys."""
+        return cls.UNKNOWN
+
+    UNKNOWN = "unknown"
     BSH_COMMON_START_IN_RELATIVE = "BSH.Common.Option.StartInRelative"
     CONSUMER_PRODUCTS_CLEANING_ROBOT_CLEANING_MODE = (
         "ConsumerProducts.CleaningRobot.Option.CleaningMode"
@@ -204,6 +210,12 @@ class ProgramKey(StrEnum):
     # Missing program categories still to be added 20241129:
     # Dryer, Hood, Oven, Warming Drawer, Washer, Washer Dryer
 
+    @classmethod
+    def _missing_(cls, _: object) -> ProgramKey:
+        """Return UNKNOWN for missing keys."""
+        return cls.UNKNOWN
+
+    UNKNOWN = "unknown"
     CONSUMER_PRODUCTS_CLEANING_ROBOT_BASIC_GO_HOME = (
         "ConsumerProducts.CleaningRobot.Program.Basic.GoHome"
     )

--- a/src/aiohomeconnect/model/setting.py
+++ b/src/aiohomeconnect/model/setting.py
@@ -69,6 +69,12 @@ class PutSettings(DataClassJSONMixin):
 class SettingKey(StrEnum):
     """Represent a setting key."""
 
+    @classmethod
+    def _missing_(cls, _: object) -> SettingKey:
+        """Return UNKNOWN for missing keys."""
+        return cls.UNKNOWN
+
+    UNKNOWN = "unknown"
     BSH_COMMON_POWER_STATE = "BSH.Common.Setting.PowerState"
     BSH_COMMON_TEMPERATURE_UNIT = "BSH.Common.Setting.TemperatureUnit"
     BSH_COMMON_LIQUID_VOLUME_UNIT = "BSH.Common.Setting.LiquidVolumeUnit"

--- a/src/aiohomeconnect/model/status.py
+++ b/src/aiohomeconnect/model/status.py
@@ -54,6 +54,12 @@ class ArrayOfStatus(DataClassJSONMixin):
 class StatusKey(StrEnum):
     """Represent a status key."""
 
+    @classmethod
+    def _missing_(cls, _: object) -> StatusKey:
+        """Return UNKNOWN for missing keys."""
+        return cls.UNKNOWN
+
+    UNKNOWN = "unknown"
     BSH_COMMON_BATTERY_CHARGING_STATE = "BSH.Common.Status.BatteryChargingState"
     BSH_COMMON_BATTERY_LEVEL = "BSH.Common.Status.BatteryLevel"
     BSH_COMMON_CHARGING_CONNECTION = "BSH.Common.Status.ChargingConnection"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Fixes:
- #38 

defined `__missing__` class method and added unknown values to `StrEnum` classes that have high probability of having unknow values. These enum classes are:

- `EventKey`
- `OptionKey`
- `ProgramKey`
- `SettingKey`
- `StatusKey`

Enumerations were unknown values haven't been allowed:

- `Language`
- `Command`

The values from these enumerations are never reported, so I think they don't require `__missing__` class method.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
