### PR TITLE
fix: raise exception only on error request

### DIFF
--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -72,14 +72,15 @@ from .model.error import (
 
 def _raise_generic_error(response: Response) -> None:
     """Raise a generic error if the response is an error."""
-    raise (
-        HomeConnectApiError.from_dict(error)
-        if (error := response.json().get("error"))
-        else HomeConnectApiError(
-            "unknown",
-            f"Unknown HTTP error (Status code: {response.status_code})",
+    if response.is_error:
+        raise (
+            HomeConnectApiError.from_dict(error)
+            if (error := response.json().get("error"))
+            else HomeConnectApiError(
+                "unknown",
+                f"Unknown HTTP error (Status code: {response.status_code})",
+            )
         )
-    )
 
 
 class AbstractAuth(ABC):
@@ -184,8 +185,7 @@ class Client:
             "/homeappliances",
             headers=None,
         )
-        if response.is_error:
-            _raise_generic_error(response)
+        _raise_generic_error(response)
         return ArrayOfHomeAppliances.from_dict(response.json()["data"])
 
     async def get_specific_appliance(
@@ -206,8 +206,7 @@ class Client:
             f"/homeappliances/{ha_id}",
             headers=None,
         )
-        if response.is_error:
-            _raise_generic_error(response)
+        _raise_generic_error(response)
         return HomeAppliance.from_dict(response.json()["data"])
 
     async def get_all_programs(
@@ -657,8 +656,7 @@ class Client:
             f"/homeappliances/{ha_id}/images",
             headers={"Accept-Language": accept_language},
         )
-        if response.is_error:
-            _raise_generic_error(response)
+        _raise_generic_error(response)
         return ArrayOfImages.from_dict(response.json()["data"])
 
     async def get_image(
@@ -697,8 +695,7 @@ class Client:
             f"/homeappliances/{ha_id}/settings",
             headers={"Accept-Language": accept_language},
         )
-        if response.is_error:
-            _raise_generic_error(response)
+        _raise_generic_error(response)
         return ArrayOfSettings.from_dict(response.json()["data"])
 
     async def set_settings(
@@ -844,8 +841,7 @@ class Client:
             headers={"Accept-Language": accept_language},
             data=put_commands.to_dict(),
         )
-        if response.is_error:
-            _raise_generic_error(response)
+        _raise_generic_error(response)
 
     async def put_command(
         self,
@@ -863,8 +859,7 @@ class Client:
             headers={"Accept-Language": accept_language},
             data=put_command.to_dict(),
         )
-        if response.is_error:
-            _raise_generic_error(response)
+        _raise_generic_error(response)
 
     async def stream_all_events(
         self,


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Some request, although the response was a 20X status code, raised errors.
To fix it, `_raise_generic_error` will always check if the response is an error response before raising the exception.
And because it would be redundant, I deleted the error check condition from all the requests (except for the event stream requests, where is still useful).

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
