### PR TITLE
fix: ignore `None` values at models used at `PUT` requests

### DIFF
--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -36,7 +36,6 @@ from .model import (
     Option,
     OptionKey,
     Program,
-    ProgramConstraints,
     ProgramDefinition,
     ProgramKey,
     PutCommand,
@@ -297,9 +296,7 @@ class Client:
         ha_id: str,
         *,
         program_key: ProgramKey,
-        name: str | None = None,
         options: list[Option] | None = None,
-        constraints: ProgramConstraints | None = None,
         accept_language: Language | None = None,
     ) -> None:
         """Start the given program.
@@ -338,9 +335,7 @@ class Client:
         There are no programs available for freezers, fridge freezers,
         refrigerators and wine coolers.
         """
-        program = Program(
-            key=program_key, name=name, options=options, constraints=constraints
-        )
+        program = Program(key=program_key, options=options)
         response = await self._auth.request(
             "PUT",
             f"/homeappliances/{ha_id}/programs/active",
@@ -524,9 +519,7 @@ class Client:
         ha_id: str,
         *,
         program_key: ProgramKey,
-        name: str | None = None,
         options: list[Option] | None = None,
-        constraints: ProgramConstraints | None = None,
         accept_language: Language | None = None,
     ) -> None:
         """Select the given program.
@@ -543,9 +536,7 @@ class Client:
         directly from the home appliance. Any changes to the available options
         due to the state of the appliance is only reflected in the selected program.
         """
-        program = Program(
-            key=program_key, name=name, options=options, constraints=constraints
-        )
+        program = Program(key=program_key, options=options)
         response = await self._auth.request(
             "PUT",
             f"/homeappliances/{ha_id}/programs/selected",

--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -296,6 +296,7 @@ class Client:
         ha_id: str,
         *,
         program_key: ProgramKey,
+        name: str | None = None,
         options: list[Option] | None = None,
         accept_language: Language | None = None,
     ) -> None:
@@ -335,7 +336,7 @@ class Client:
         There are no programs available for freezers, fridge freezers,
         refrigerators and wine coolers.
         """
-        program = Program(key=program_key, options=options)
+        program = Program(key=program_key, name=name, options=options)
         response = await self._auth.request(
             "PUT",
             f"/homeappliances/{ha_id}/programs/active",
@@ -519,6 +520,7 @@ class Client:
         ha_id: str,
         *,
         program_key: ProgramKey,
+        name: str | None = None,
         options: list[Option] | None = None,
         accept_language: Language | None = None,
     ) -> None:
@@ -536,7 +538,7 @@ class Client:
         directly from the home appliance. Any changes to the available options
         due to the state of the appliance is only reflected in the selected program.
         """
-        program = Program(key=program_key, options=options)
+        program = Program(key=program_key, name=name, options=options)
         response = await self._auth.request(
             "PUT",
             f"/homeappliances/{ha_id}/programs/selected",

--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import Any
 
 from mashumaro import field_options
+from mashumaro.config import BaseConfig
 from mashumaro.mixins.json import DataClassJSONMixin
 
 
@@ -18,6 +19,11 @@ class Program(DataClassJSONMixin):
     name: str | None = None
     options: list[Option] | None = None
     constraints: ProgramConstraints | None = None
+
+    class Config(BaseConfig):
+        """Config for mashumaro."""
+
+        omit_none = True
 
 
 @dataclass
@@ -137,6 +143,11 @@ class Option(DataClassJSONMixin):
         default=None, metadata=field_options(alias="displayvalue")
     )
     unit: str | None = None
+
+    class Config(BaseConfig):
+        """Config for mashumaro."""
+
+        omit_none = True
 
 
 @dataclass


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
Home Connect API is raising bad request http errors because it is expecting an specific data type, but instead gets null.

To fix that, I added a `Config` inside those classes that were rising problems it, with `omit_none` set to `True`.

Additionally, I removed some parameters from `start_program` and `set_selected_prgram` that aren't specified to be required at API documentation .
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
