### PR TITLE
fix: make program model key optional

### DIFF
--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -15,7 +15,7 @@ from mashumaro.mixins.json import DataClassJSONMixin
 class Program(DataClassJSONMixin):
     """Represent Program."""
 
-    key: ProgramKey
+    key: ProgramKey | None = None
     name: str | None = None
     options: list[Option] | None = None
     constraints: ProgramConstraints | None = None


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
- We're using the `Program` model for the active and selected program in the array of programs model and also for the get active program and get selected program methods. The expected model according to the docs in these cases have the same attributes but the required attributes differ. Make all `Program` attributes optional so we can keep using this model for these cases.
- https://apiclient.home-connect.com/?url=https%3A//apiclient.home-connect.com/hcsdk-production.yaml#/programs/get_all_programs
- https://apiclient.home-connect.com/?url=https%3A//apiclient.home-connect.com/hcsdk-production.yaml#/programs/get_active_program
- https://apiclient.home-connect.com/?url=https%3A//apiclient.home-connect.com/hcsdk-production.yaml#/programs/get_selected_program

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
