### PR TITLE
feat: add retry after info from rate limit error

### DIFF
--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -143,8 +143,7 @@ class AbstractAuth(ABC):
             case codes.TOO_MANY_REQUESTS:
                 err = TooManyRequestsError.from_dict(response.json()["error"])
                 retry_after = response.headers.get("Retry-After")
-                if retry_after is not None:
-                    err.retry_after = int(retry_after)
+                err.retry_after = int(retry_after) if retry_after else None
                 raise err
             case codes.INTERNAL_SERVER_ERROR:
                 raise InternalServerError.from_dict(response.json()["error"])

--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -141,7 +141,9 @@ class AbstractAuth(ABC):
             case codes.UNSUPPORTED_MEDIA_TYPE:
                 raise UnsupportedMediaTypeError.from_dict(response.json()["error"])
             case codes.TOO_MANY_REQUESTS:
-                raise TooManyRequestsError.from_dict(response.json()["error"])
+                err = TooManyRequestsError.from_dict(response.json()["error"])
+                err.retry_after = int(response.headers.get("Retry-After"))
+                raise err
             case codes.INTERNAL_SERVER_ERROR:
                 raise InternalServerError.from_dict(response.json()["error"])
             case _:

--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -142,7 +142,9 @@ class AbstractAuth(ABC):
                 raise UnsupportedMediaTypeError.from_dict(response.json()["error"])
             case codes.TOO_MANY_REQUESTS:
                 err = TooManyRequestsError.from_dict(response.json()["error"])
-                err.retry_after = int(response.headers.get("Retry-After"))
+                retry_after = response.headers.get("Retry-After")
+                if retry_after is not None:
+                    err.retry_after = int(retry_after)
                 raise err
             case codes.INTERNAL_SERVER_ERROR:
                 raise InternalServerError.from_dict(response.json()["error"])

--- a/src/aiohomeconnect/model/error.py
+++ b/src/aiohomeconnect/model/error.py
@@ -97,6 +97,8 @@ class UnsupportedMediaTypeError(HomeConnectApiError):
 class TooManyRequestsError(HomeConnectApiError):
     """Represent TooManyRequestsError."""
 
+    retry_after: int | None = None
+
 
 @dataclass
 class InternalServerError(HomeConnectApiError):


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The HTTP error 429 usually can send a header that contains the time required to continue with the requests (`Retry-After`)
This changes pretend to catch it and expose it through the `TooManyRequestsError`.

more info: https://api-docs.home-connect.com/general/#rate-limiting

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
