### PR TITLE
feat: add logs for unknown keys in event, program, setting and status keys

### DIFF
--- a/src/aiohomeconnect/model/event.py
+++ b/src/aiohomeconnect/model/event.py
@@ -10,6 +10,7 @@ from httpx_sse import ServerSentEvent
 from mashumaro import field_options
 from mashumaro.mixins.json import DataClassJSONMixin
 
+from aiohomeconnect.const import LOGGER
 from aiohomeconnect.model.program import OptionKey
 from aiohomeconnect.model.setting import SettingKey
 from aiohomeconnect.model.status import StatusKey
@@ -73,8 +74,9 @@ class EventKey(StrEnum):
     """Represent an event key."""
 
     @classmethod
-    def _missing_(cls, _: object) -> EventKey:
+    def _missing_(cls, value: object) -> EventKey:
         """Return UNKNOWN for missing keys."""
+        LOGGER.debug("Unknown event key: %s", value)
         return cls.UNKNOWN
 
     UNKNOWN = "unknown"

--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -10,6 +10,8 @@ from mashumaro import field_options
 from mashumaro.config import BaseConfig
 from mashumaro.mixins.json import DataClassJSONMixin
 
+from aiohomeconnect.const import LOGGER
+
 
 @dataclass
 class Program(DataClassJSONMixin):
@@ -163,8 +165,9 @@ class OptionKey(StrEnum):
     """Represent an option key."""
 
     @classmethod
-    def _missing_(cls, _: object) -> OptionKey:
+    def _missing_(cls, value: object) -> OptionKey:
         """Return UNKNOWN for missing keys."""
+        LOGGER.debug("Unknown option key: %s", value)
         return cls.UNKNOWN
 
     UNKNOWN = "unknown"
@@ -227,8 +230,9 @@ class ProgramKey(StrEnum):
     """Represent a program key."""
 
     @classmethod
-    def _missing_(cls, _: object) -> ProgramKey:
+    def _missing_(cls, value: object) -> ProgramKey:
         """Return UNKNOWN for missing keys."""
+        LOGGER.debug("Unknown program key: %s", value)
         return cls.UNKNOWN
 
     UNKNOWN = "unknown"

--- a/src/aiohomeconnect/model/setting.py
+++ b/src/aiohomeconnect/model/setting.py
@@ -9,6 +9,8 @@ from typing import Any
 from mashumaro import field_options
 from mashumaro.mixins.json import DataClassJSONMixin
 
+from aiohomeconnect.const import LOGGER
+
 
 @dataclass
 class GetSetting(DataClassJSONMixin):
@@ -71,8 +73,9 @@ class SettingKey(StrEnum):
     """Represent a setting key."""
 
     @classmethod
-    def _missing_(cls, _: object) -> SettingKey:
+    def _missing_(cls, value: object) -> SettingKey:
         """Return UNKNOWN for missing keys."""
+        LOGGER.debug("Unknown setting key: %s", value)
         return cls.UNKNOWN
 
     UNKNOWN = "unknown"

--- a/src/aiohomeconnect/model/status.py
+++ b/src/aiohomeconnect/model/status.py
@@ -9,6 +9,8 @@ from typing import Any
 from mashumaro import field_options
 from mashumaro.mixins.json import DataClassJSONMixin
 
+from aiohomeconnect.const import LOGGER
+
 
 @dataclass
 class Status(DataClassJSONMixin):
@@ -56,8 +58,9 @@ class StatusKey(StrEnum):
     """Represent a status key."""
 
     @classmethod
-    def _missing_(cls, _: object) -> StatusKey:
+    def _missing_(cls, value: object) -> StatusKey:
         """Return UNKNOWN for missing keys."""
+        LOGGER.debug("Unknown status key: %s", value)
         return cls.UNKNOWN
 
     UNKNOWN = "unknown"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

To assist a little bit more to know which keys are not added to the library, I added these logs

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
