### PR TITLE
fix: handle no content on HTTP error

### DIFF
--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -75,7 +75,7 @@ def _raise_generic_error(response: Response) -> None:
     if response.is_error:
         raise (
             HomeConnectApiError.from_dict(error)
-            if (error := response.json().get("error"))
+            if response.content and (error := response.json().get("error"))
             else HomeConnectApiError(
                 "unknown",
                 f"Unknown HTTP error (Status code: {response.status_code})",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -239,6 +239,22 @@ async def test_generic_http_error(
         await client.get_home_appliances()
 
 
+async def test_generic_http_error_no_content(
+    httpx_client: AsyncClient,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Test stream all events http error with no content."""
+    httpx_mock.add_response(
+        url="https://example.com/api/homeappliances",
+        status_code=codes.IM_A_TEAPOT,
+    )
+
+    client = Client(AuthClient(httpx_client, "https://example.com"))
+
+    with pytest.raises(HomeConnectApiError):
+        await client.get_home_appliances()
+
+
 async def test_rate_limit_error(
     httpx_client: AsyncClient, httpx_mock: HTTPXMock
 ) -> None:


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

I faced some HTTP errors that didn't had any content, which broke the Home Assistant integration.
This PR fixes that.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
