### PR TITLE
fix: set higher timeout for requests

### DIFF
--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -124,6 +124,7 @@ class AbstractAuth(ABC):
                 **kwargs,
                 headers=headers,
                 json={"data": data} if data is not None else None,
+                timeout=Timeout(5, read=30),
             )
         except RequestError as e:
             raise HomeConnectRequestError(f"{type(e).__name__}: {e}") from e


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Set a higher timeout for requests that can take a little bit longer.
I set the read timeout (where I think the problem was located) to 30 seconds, and the rests of timeout to 5 seconds.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
