### PR TITLE
feat: add bread baking and dough proving program keys

### DIFF
--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -389,9 +389,15 @@ class ProgramKey(StrEnum):
     COOKING_OVEN_HEATING_MODE_BOTTOM_HEATING = (
         "Cooking.Oven.Program.HeatingMode.BottomHeating"
     )
+    COOKING_OVEN_HEATING_MODE_BREAD_BAKING = (
+        "Cooking.Oven.Program.HeatingMode.BreadBaking"
+    )
     COOKING_OVEN_HEATING_MODE_DEFROST = "Cooking.Oven.Program.HeatingMode.Defrost"
     COOKING_OVEN_HEATING_MODE_DESICCATION = (
         "Cooking.Oven.Program.HeatingMode.Desiccation"
+    )
+    COOKING_OVEN_HEATING_MODE_DOUGH_PROVING = (
+        "Cooking.Oven.Program.HeatingMode.DoughProving"
     )
     COOKING_OVEN_HEATING_MODE_FROZEN_HEATUP_SPECIAL = (
         "Cooking.Oven.Program.HeatingMode.FrozenHeatupSpecial"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Add bread baking and dough proving program keys.

Spotted them at https://github.com/home-assistant/core/issues/165483#issuecomment-4060703381

```
2026-03-14 16:05:37.840 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='KEEP-ALIVE')
2026-03-14 16:05:39.734 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"BSH.Common.Status.LocalControlActive","level":"hint","name":"Local operation active","timestamp":1773500739,"uri":"/api/homeappliances/305110427010013769-001/status/BSH.Common.Status.LocalControlActive","value":true}]}', id='305110427010013769-001')
2026-03-14 16:05:39.750 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity binary_sensor.four_controle_local=on>
2026-03-14 16:05:40.128 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"Cooking.Oven.Status.CurrentCavityTemperature","level":"hint","timestamp":1773500740,"unit":"°C","uri":"/api/homeappliances/305110427010013769-001/status/Cooking.Oven.Status.CurrentCavityTemperature","value":29}]}', id='305110427010013769-001')
2026-03-14 16:05:40.130 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity sensor.four_current_oven_cavity_temperature=29>
2026-03-14 16:05:43.604 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='NOTIFY', data='{"haId":"305110427010013769-001","items":[{"displayvalue":"On","handling":"none","key":"BSH.Common.Setting.PowerState","level":"hint","name":"Power status","timestamp":1773500743,"uri":"/api/homeappliances/305110427010013769-001/settings/BSH.Common.Setting.PowerState","value":"BSH.Common.EnumType.PowerState.On"}]}', id='305110427010013769-001')
2026-03-14 16:05:43.605 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity switch.four_etat=on>
2026-03-14 16:05:44.198 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"displayvalue":"Ready","handling":"none","key":"BSH.Common.Status.OperationState","level":"hint","name":"Operation state","timestamp":1773500744,"uri":"/api/homeappliances/305110427010013769-001/status/BSH.Common.Status.OperationState","value":"BSH.Common.EnumType.OperationState.Ready"}]}', id='305110427010013769-001')
2026-03-14 16:05:44.199 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity sensor.four_etat=ready>
2026-03-14 16:05:44.726 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"BSH.Common.Status.LocalControlActive","level":"hint","name":"Local operation active","timestamp":1773500744,"uri":"/api/homeappliances/305110427010013769-001/status/BSH.Common.Status.LocalControlActive","value":false}]}', id='305110427010013769-001')
2026-03-14 16:05:44.727 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity binary_sensor.four_controle_local=off>
2026-03-14 16:05:45.561 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"BSH.Common.Status.LocalControlActive","level":"hint","name":"Local operation active","timestamp":1773500745,"uri":"/api/homeappliances/305110427010013769-001/status/BSH.Common.Status.LocalControlActive","value":true}]}', id='305110427010013769-001')
2026-03-14 16:05:45.561 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity binary_sensor.four_controle_local=on>
2026-03-14 16:05:45.704 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"Cooking.Oven.Status.CurrentCavityTemperature","level":"hint","timestamp":1773500745,"unit":"°C","uri":"/api/homeappliances/305110427010013769-001/status/Cooking.Oven.Status.CurrentCavityTemperature","value":20}]}', id='305110427010013769-001')
2026-03-14 16:05:45.705 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity sensor.four_current_oven_cavity_temperature=20>
2026-03-14 16:05:59.173 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='NOTIFY', data='{"haId":"305110427010013769-001","items":[{"displayvalue":"Bread-baking","handling":"none","key":"BSH.Common.Root.SelectedProgram","level":"hint","timestamp":1773500759,"uri":"/api/homeappliances/305110427010013769-001/programs/selected","value":"Cooking.Oven.Program.HeatingMode.BreadBaking"}]}', id='305110427010013769-001')
2026-03-14 16:05:59.173 DEBUG (MainThread) [aiohomeconnect] Unknown program key: Cooking.Oven.Program.HeatingMode.BreadBaking
2026-03-14 16:05:59.174 DEBUG (MainThread) [aiohomeconnect] Unknown program key: Cooking.Oven.Program.HeatingMode.BreadBaking
2026-03-14 16:05:59.174 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity select.four_programme_selectionne=unknown>
2026-03-14 16:06:03.452 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"BSH.Common.Status.LocalControlActive","level":"hint","name":"Local operation active","timestamp":1773500763,"uri":"/api/homeappliances/305110427010013769-001/status/BSH.Common.Status.LocalControlActive","value":false}]}', id='305110427010013769-001')
2026-03-14 16:06:03.454 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity binary_sensor.four_controle_local=off>
```

```
2026-03-14 16:11:10.009 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='STATUS', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"Cooking.Oven.Status.CurrentCavityTemperature","level":"hint","timestamp":1773501069,"unit":"°C","uri":"/api/homeappliances/305110427010013769-001/status/Cooking.Oven.Status.CurrentCavityTemperature","value":31}]}', id='305110427010013769-001')
2026-03-14 16:11:10.010 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity sensor.four_current_oven_cavity_temperature=31>
2026-03-14 16:11:11.690 ERROR (MainThread) [homeassistant.components.playstation_network.coordinator] Error fetching playstation_network data: Data retrieval failed when trying to access the PlayStation Network
2026-03-14 16:11:16.423 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='NOTIFY', data='{"haId":"305110427010013769-001","items":[{"displayvalue":"Dough proving","handling":"none","key":"BSH.Common.Root.SelectedProgram","level":"hint","timestamp":1773501076,"uri":"/api/homeappliances/305110427010013769-001/programs/selected","value":"Cooking.Oven.Program.HeatingMode.DoughProving"}]}', id='305110427010013769-001')
2026-03-14 16:11:16.424 DEBUG (MainThread) [aiohomeconnect] Unknown program key: Cooking.Oven.Program.HeatingMode.DoughProving
2026-03-14 16:11:16.424 DEBUG (MainThread) [aiohomeconnect] Unknown program key: Cooking.Oven.Program.HeatingMode.DoughProving
2026-03-14 16:11:16.425 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity select.four_programme_selectionne=unknown>
2026-03-14 16:11:22.393 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='NOTIFY', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"BSH.Common.Option.ProgramProgress","level":"hint","name":"Current program progress","timestamp":1773501082,"unit":"%","uri":"/api/homeappliances/305110427010013769-001/programs/selected/BSH.Common.Option.ProgramProgress","value":0}]}', id='305110427010013769-001')
2026-03-14 16:11:22.394 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity sensor.four_progression_du_programme=unavailable>
2026-03-14 16:11:22.397 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='NOTIFY', data='{"haId":"305110427010013769-001","items":[{"displayvalue":"Dough proving","handling":"none","key":"BSH.Common.Root.ActiveProgram","level":"hint","timestamp":1773501082,"uri":"/api/homeappliances/305110427010013769-001/programs/active","value":"Cooking.Oven.Program.HeatingMode.DoughProving"},{"handling":"none","key":"Cooking.Oven.Option.SetpointTemperature","level":"hint","name":"Cavity temperature","timestamp":1773501082,"unit":"°C","uri":"/api/homeappliances/305110427010013769-001/programs/selected/Cooking.Oven.Option.SetpointTemperature","value":40},{"handling":"none","key":"BSH.Common.Option.Duration","level":"hint","name":"Adjust the duration","timestamp":1773501082,"unit":"seconds","uri":"/api/homeappliances/305110427010013769-001/programs/selected/BSH.Common.Option.Duration","value":1200}]}', id='305110427010013769-001')
2026-03-14 16:11:22.397 DEBUG (MainThread) [aiohomeconnect] Unknown program key: Cooking.Oven.Program.HeatingMode.DoughProving
2026-03-14 16:11:22.397 DEBUG (MainThread) [aiohomeconnect] Unknown program key: Cooking.Oven.Program.HeatingMode.DoughProving
2026-03-14 16:11:22.398 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity select.four_programme_actif=unknown>
2026-03-14 16:11:22.399 DEBUG (MainThread) [aiohomeconnect] Event: ServerSentEvent(event='NOTIFY', data='{"haId":"305110427010013769-001","items":[{"handling":"none","key":"BSH.Common.Option.RemainingProgramTime","level":"hint","name":"Remaining program running time","timestamp":1773501082,"unit":"seconds","uri":"/api/homeappliances/305110427010013769-001/programs/selected/BSH.Common.Option.RemainingProgramTime","value":1200},{"handling":"none","key":"BSH.Common.Option.ElapsedProgramTime","level":"hint","name":"Program running time","timestamp":1773501082,"unit":"seconds","uri":"/api/homeappliances/305110427010013769-001/programs/selected/BSH.Common.Option.ElapsedProgramTime","value":0}]}', id='305110427010013769-001')
2026-03-14 16:11:22.400 DEBUG (MainThread) [homeassistant.components.home_connect.entity] Updated <entity sensor.four_heure_de_fin_de_programme=unavailable>
```

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
