### PR TITLE
fix: use float instead of int for retry_after

### DIFF
--- a/src/aiohomeconnect/client.py
+++ b/src/aiohomeconnect/client.py
@@ -145,7 +145,7 @@ class AbstractAuth(ABC):
             case codes.TOO_MANY_REQUESTS:
                 err = TooManyRequestsError.from_dict(response.json()["error"])
                 retry_after = response.headers.get("Retry-After")
-                err.retry_after = int(retry_after) if retry_after else None
+                err.retry_after = float(retry_after) if retry_after else None
                 raise err
             case codes.INTERNAL_SERVER_ERROR:
                 raise InternalServerError.from_dict(response.json()["error"])

--- a/src/aiohomeconnect/model/error.py
+++ b/src/aiohomeconnect/model/error.py
@@ -96,7 +96,7 @@ class UnsupportedMediaTypeError(HomeConnectApiError):
 class TooManyRequestsError(HomeConnectApiError):
     """Represent TooManyRequestsError."""
 
-    retry_after: int | None = None
+    retry_after: float | None = None
 
 
 @dataclass


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Fix for https://github.com/home-assistant/core/issues/172146

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
