### PR TITLE
feat: mapped keys

### DIFF
--- a/src/aiohomeconnect/model/program.py
+++ b/src/aiohomeconnect/model/program.py
@@ -404,7 +404,9 @@ class ProgramKey(StrEnum):
 
     @classmethod
     def _missing_(cls, value: object) -> ProgramKey:
-        """Return UNKNOWN for missing keys."""
+        """Return UNKNOWN or mapped ones for missing keys."""
+        if isinstance(value, str) and value in _mapped_program_keys:
+            return _mapped_program_keys[value]
         LOGGER.debug("Unknown program key: %s", value)
         return cls.UNKNOWN
 
@@ -961,3 +963,25 @@ class ProgramKey(StrEnum):
         "LaundryCare.WasherDryer.Program.WashAndDry.90"
     )
     LAUNDRY_CARE_WASHER_DRYER_WOOL = "LaundryCare.WasherDryer.Program.Wool"
+
+
+_mapped_program_keys = {
+    "LaundryCare.WasherDryer.Program.Cotton.Cotton.Cotton": (
+        ProgramKey.LAUNDRY_CARE_WASHER_DRYER_COTTON
+    ),
+    "LaundryCare.WasherDryer.Program.DelicatesSilk.DelicatesSilk.DelicatesSilk": (
+        ProgramKey.LAUNDRY_CARE_WASHER_DRYER_DELICATES_SILK
+    ),
+    "LaundryCare.WasherDryer.Program.DrumCleanDry.DrumCare.DrumCare": (
+        ProgramKey.LAUNDRY_CARE_WASHER_DRYER_DRUM_CLEAN_AND_DRY_DRUM_CARE
+    ),
+    "LaundryCare.WasherDryer.Program.Rinse.Rinse.Rinse": (
+        ProgramKey.LAUNDRY_CARE_WASHER_DRYER_RINSE
+    ),
+    "LaundryCare.WasherDryer.Program.Sensitive.Sensitive.Sensitive": (
+        ProgramKey.LAUNDRY_CARE_WASHER_DRYER_SENSITIVE
+    ),
+    "LaundryCare.WasherDryer.Program.Wool.Wool.Wool": (
+        ProgramKey.LAUNDRY_CARE_WASHER_DRYER_WOOL
+    ),
+}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,7 @@
 """Tests for the model module."""
 
+import pytest
+
 from aiohomeconnect.model import EventKey, OptionKey, ProgramKey, SettingKey, StatusKey
 
 
@@ -43,3 +45,37 @@ async def test_options_settings_status_references_at_events() -> None:
             assert event_key in StatusKey.__members__.values(), (
                 f"EventKey.{event_key.name} not in StatusKey enumeration"
             )
+
+
+@pytest.mark.parametrize(
+    ("str_key", "expected_enum_key"),
+    [
+        (
+            "LaundryCare.WasherDryer.Program.Cotton.Cotton.Cotton",
+            ProgramKey.LAUNDRY_CARE_WASHER_DRYER_COTTON,
+        ),
+        (
+            "LaundryCare.WasherDryer.Program.DelicatesSilk.DelicatesSilk.DelicatesSilk",
+            ProgramKey.LAUNDRY_CARE_WASHER_DRYER_DELICATES_SILK,
+        ),
+        (
+            "LaundryCare.WasherDryer.Program.DrumCleanDry.DrumCare.DrumCare",
+            ProgramKey.LAUNDRY_CARE_WASHER_DRYER_DRUM_CLEAN_AND_DRY_DRUM_CARE,
+        ),
+        (
+            "LaundryCare.WasherDryer.Program.Rinse.Rinse.Rinse",
+            ProgramKey.LAUNDRY_CARE_WASHER_DRYER_RINSE,
+        ),
+        (
+            "LaundryCare.WasherDryer.Program.Sensitive.Sensitive.Sensitive",
+            ProgramKey.LAUNDRY_CARE_WASHER_DRYER_SENSITIVE,
+        ),
+        (
+            "LaundryCare.WasherDryer.Program.Wool.Wool.Wool",
+            ProgramKey.LAUNDRY_CARE_WASHER_DRYER_WOOL,
+        ),
+    ],
+)
+async def test_mapped_program_keys(str_key: str, expected_enum_key: ProgramKey) -> None:
+    """Test that the string keys are correctly mapped to the enum keys."""
+    assert ProgramKey(str_key) is expected_enum_key


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Add keys that need to be remapped to some of the docummented ones.

After some talk with Home Connect team, it was specified that some keys are wrong and need to be remapped to one of the documented ones

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiohomeconnect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
